### PR TITLE
#16: Add project badges for Gitlab build status and code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # todo
 
-[![pipeline status](https://gitlab.com/muhammadfarag/todo/badges/master/pipeline.svg)](https://gitlab.com/muhammadfarag/todo/commits/master)
-
 [![codecov](https://codecov.io/gh/MuhammadFarag/todo/branch/master/graph/badge.svg?token=DPH4YQEvqR)](https://codecov.io/gh/MuhammadFarag/todo)


### PR DESCRIPTION
Add code coverage badge to the project README. The master badge looks like this [![codecov](https://codecov.io/gh/MuhammadFarag/todo/branch/master/graph/badge.svg?token=DPH4YQEvqR)](https://codecov.io/gh/MuhammadFarag/todo). As long as we didn't merge the code coverage branch to master, it will be gray.

The code coverage branch badge: [![codecov](https://codecov.io/gh/MuhammadFarag/todo/branch/%2315-test-coverage/graph/badge.svg?token=DPH4YQEvqR)](https://codecov.io/gh/MuhammadFarag/todo)